### PR TITLE
Fix deprecated qt backgroundcolorrole in rqt_rosmon

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -133,6 +133,19 @@ fi
 
 print_success "Source code downloaded successfully"
 
+# Step 3.5: Apply source patches (Qt deprecations)
+print_status "Step 3.5: Applying source patches..."
+if [ -d "src/rosmon/rqt_rosmon" ]; then
+    print_status "Patching rqt_rosmon Qt roles..."
+    # Replace deprecated Qt roles to avoid -Werror build failures
+    find src/rosmon/rqt_rosmon -type f \( -name '*.cpp' -o -name '*.h' \) -print0 | xargs -0 sed -i \
+        -e 's/Qt::BackgroundColorRole/Qt::BackgroundRole/g' \
+        -e 's/Qt::TextColorRole/Qt::ForegroundRole/g'
+    print_success "Patched rqt_rosmon."
+else
+    print_warning "rqt_rosmon source not found; skipping rqt_rosmon patch."
+fi
+
 # Step 4: Create install directories
 print_status "Step 4: Creating install directories..."
 


### PR DESCRIPTION
Replaces deprecated Qt roles in `rqt_rosmon` to fix build errors.

The build failed due to `Qt::BackgroundColorRole` being deprecated and treated as an error. This change adds an automated patch step to `build.sh` to ensure the fix is applied consistently, especially when sources are downloaded.

---
<a href="https://cursor.com/background-agent?bcId=bc-08a46e7b-cabb-4de0-b0af-9e60cd509fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-08a46e7b-cabb-4de0-b0af-9e60cd509fea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

