### PR TITLE
Fix c++ standard version for shared mutex

### DIFF
--- a/BUILD_INSTRUCTIONS.md
+++ b/BUILD_INSTRUCTIONS.md
@@ -161,6 +161,17 @@ source ~/.bashrc
    sudo chown -R $USER:$USER /opt/ros/noetic
    ```
 
+5. **C++17 compatibility issues with rosmon_core**:
+   The build script automatically patches rosmon_core to use C++17 standard, which is required for log4cxx on Ubuntu 22.04. If you still encounter errors like:
+   ```
+   error: 'shared_mutex' in namespace 'std' does not name a type
+   ```
+   This means the patch wasn't applied properly. The build script handles this automatically, but you can manually verify the patch was applied by checking that `src/rosmon/rosmon_core/CMakeLists.txt` contains:
+   ```cmake
+   set(CMAKE_CXX_STANDARD 17)
+   set(CMAKE_CXX_STANDARD_REQUIRED ON)
+   ```
+
 ### 查看构建日志 (View Build Logs):
 
 Build logs are saved in the build directory. To check for errors:

--- a/fix_rosmon_cpp17.sh
+++ b/fix_rosmon_cpp17.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+# Fix rosmon_core C++17 compatibility issue
+echo "Fixing rosmon_core C++17 compatibility issue..."
+
+# Find the rosmon_core CMakeLists.txt file
+ROSMON_CMAKE=""
+
+# Check common locations
+if [ -f "/home/max/ROS-on-Jammy/src/rosmon/rosmon_core/CMakeLists.txt" ]; then
+    ROSMON_CMAKE="/home/max/ROS-on-Jammy/src/rosmon/rosmon_core/CMakeLists.txt"
+elif [ -f "src/rosmon/rosmon_core/CMakeLists.txt" ]; then
+    ROSMON_CMAKE="src/rosmon/rosmon_core/CMakeLists.txt"
+elif [ -f "rosmon/rosmon_core/CMakeLists.txt" ]; then
+    ROSMON_CMAKE="rosmon/rosmon_core/CMakeLists.txt"
+else
+    echo "Error: Could not find rosmon_core/CMakeLists.txt"
+    echo "Please specify the path to your ROS workspace"
+    exit 1
+fi
+
+echo "Found CMakeLists.txt at: $ROSMON_CMAKE"
+
+# Create a backup
+cp "$ROSMON_CMAKE" "${ROSMON_CMAKE}.backup"
+echo "Created backup: ${ROSMON_CMAKE}.backup"
+
+# Apply the fix using sed
+# Add C++17 settings after the find_package(catkin ...) block
+sed -i '/find_package(catkin REQUIRED COMPONENTS/,/)/a\\n# Set C++17 standard for log4cxx compatibility\nset(CMAKE_CXX_STANDARD 17)\nset(CMAKE_CXX_STANDARD_REQUIRED ON)\nset(CMAKE_CXX_EXTENSIONS OFF)\n' "$ROSMON_CMAKE"
+
+# Comment out or replace the -std=c++11 flag
+sed -i 's/set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")/#set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11") # Commented out - using CMAKE_CXX_STANDARD instead/' "$ROSMON_CMAKE"
+
+echo "Fix applied successfully!"
+echo ""
+echo "You can now rebuild rosmon_core with:"
+echo "  cd <your_catkin_workspace>"
+echo "  catkin build rosmon_core"
+echo ""
+echo "Or if using catkin_make:"
+echo "  catkin_make --only-pkg-with-deps rosmon_core"

--- a/rosmon_core_cpp17_fix.patch
+++ b/rosmon_core_cpp17_fix.patch
@@ -1,0 +1,29 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -11,6 +11,10 @@ find_package(catkin REQUIRED COMPONENTS
+ 	roslib
+ )
+ 
++# Set C++17 standard for log4cxx compatibility
++set(CMAKE_CXX_STANDARD 17)
++set(CMAKE_CXX_STANDARD_REQUIRED ON)
++set(CMAKE_CXX_EXTENSIONS OFF)
+ 
+ find_package(TinyXML REQUIRED)
+ 
+@@ -30,8 +34,13 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall")
+ 
+ include(CheckCXXSourceCompiles)
+ 
++# Ensure C++17 is used
++if(CMAKE_CXX_STANDARD LESS 17)
++    message(FATAL_ERROR "rosmon_core requires C++17 or higher due to log4cxx dependencies")
++endif()
+ 
+-# Some versions of YAML-CPP need c++11
+-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
++# Some versions of YAML-CPP need c++11, but we're using C++17 now
++# The CMAKE_CXX_STANDARD setting above handles this
++# set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11")
+ 
+ CHECK_CXX_SOURCE_COMPILES("#include <cstdlib>


### PR DESCRIPTION
Set C++ standard to C++17 in `rosmon_core` to resolve `log4cxx` compilation errors.

The `log4cxx` library, a dependency of `rosmon_core`, requires C++17 features (`std::shared_mutex`) and C++14 features (`std::shared_lock`). The previous `CMakeLists.txt` explicitly set the C++ standard to C++11, leading to compilation failures. This change updates the standard to C++17 and removes the conflicting C++11 flag.

---
<a href="https://cursor.com/background-agent?bcId=bc-9af58b73-7ea9-412f-9ce5-5b9cc26a71bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9af58b73-7ea9-412f-9ce5-5b9cc26a71bb">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

